### PR TITLE
Don't attempt to decorate Nil by default

### DIFF
--- a/lib/little_decorator/helper.rb
+++ b/lib/little_decorator/helper.rb
@@ -1,11 +1,13 @@
 class LittleDecorator
   module Helper
 
-    def decorate(item_or_collection)
+    def decorate(item_or_collection, decorate_nils: false)
       if item_or_collection.respond_to?(:map)
         item_or_collection.map{ |item| decorate(item) }
       else
         item = item_or_collection
+        return nil if item.nil? && !decorate_nils
+        
         decorator = "#{item.class}Decorator".constantize
         decorator.new(item, self)
       end

--- a/spec/fixtures/rails_app.rb
+++ b/spec/fixtures/rails_app.rb
@@ -13,7 +13,10 @@ module Rails
     def routes
       @routes ||= ActionDispatch::Routing::RouteSet.new.tap do |routes|
         routes.draw do
-          resource :users
+          resource :users do
+            get :missing, on: :member
+            get :nils, on: :member
+          end
         end
       end
     end

--- a/spec/fixtures/users_controller.rb
+++ b/spec/fixtures/users_controller.rb
@@ -5,4 +5,14 @@ class UsersController < ApplicationConroller
     render nothing: true
   end
 
+  def missing
+    decorate([])
+    render nothing: true
+  end
+
+  def nils
+    decorate(nil)
+    render nothing: true
+  end
+
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -14,4 +14,14 @@ describe UsersController, type: :controller do
     get :show
   end
 
+  it "passes empty-collections through" do
+    expect(UserDecorator).not_to receive(:new)
+    get :missing
+  end
+
+  it "passes empty-collections through" do
+    expect(UserDecorator).not_to receive(:new)
+    get :nils
+  end
+
 end


### PR DESCRIPTION
If you want to decorate nil for some reason, use the `decorate_nils:
true` options.
