### PR TITLE
Raise ArgumentError if a nil is passed to the LittleDecorator Helper

### DIFF
--- a/lib/little_decorator/helper.rb
+++ b/lib/little_decorator/helper.rb
@@ -6,12 +6,19 @@ class LittleDecorator
         item_or_collection.map{ |item| decorate(item) }
       else
         item = item_or_collection
-        return item if LittleDecorator === item
+        raise_argument_error if item.nil?
+        return item     if LittleDecorator === item
         decorator = "#{item.class}Decorator".constantize
         decorator.new(item, self)
       end
     end
     alias_method :d, :decorate
+
+    private
+
+    def raise_argument_error
+      raise ArgumentError, 'A nil was passed into the decorator.'
+    end
 
   end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+include LittleDecorator::Helper
+
+describe 'LittleDecorator::Helper' do
+
+  context '#decorate is called on a nil record' do
+    it 'raises an ArgumentError if the model is nil' do
+      expect{ decorate(nil) }.to raise_error(ArgumentError)
+    end
+  end
+
+end
+
+


### PR DESCRIPTION
When a nil is passed into LittleDecorator::Helper#decorate, you get a `NameError: uninitialized constant NilClassDecorator` error.

With this PR, when a nil is passed into the helper, an ArgumentError is raised, letting you know you passed in a nil.

Cheers!
